### PR TITLE
Feat:  jump to heading

### DIFF
--- a/clojure/resources/firn/_firn_starter/static/css/main.css
+++ b/clojure/resources/firn/_firn_starter/static/css/main.css
@@ -143,3 +143,7 @@ img {
 
 .firn-headline-timestamp {}
 .firn-headline-cookie {}
+
+/* Other "Components" */
+.firn-footnote-ref {}
+.firn-footnote-def {}

--- a/clojure/src/firn/org.clj
+++ b/clojure/src/firn/org.clj
@@ -22,7 +22,7 @@
         (prn "Orgize failed to parse file." stripped res)
         (res :out)))))
 
-(defn- get-headline-helper
+(defn get-headline-helper
   "Sanitizes a heading of links and just returns text.
   Necessary because org leafs of :type `link` have a `:desc` and not a `:value`
 
@@ -48,15 +48,16 @@
                        (case (:type child)
                          "text" (get-trimmed-val child :value)
                          "link" (get-trimmed-val child :desc)
+                         "code" (get-trimmed-val child :value)
                          "")))))))
 
 (defn get-headline
   "Fetches a headline from an org-mode tree."
   [tree name]
   (->> (tree-seq map? :children tree)
-       (filter #(and (= "headline" (:type %))
-                     (= name (get-headline-helper %))))
-       (first)))
+     (filter #(and (= "headline" (:type %))
+                   (= name (get-headline-helper %))))
+     (first)))
 
 (defn get-headline-content
   "Same as get-headline, but removes the first child :title)."
@@ -100,7 +101,6 @@
         :log-sum   log-sum
         :hour-sum  (u/timestr->hour-float log-sum)}))))
 
-
 (defn logbook-year-stats
   "Takes a logbook and pushes it's data into a year calendar.
   Returns a map that looks like:
@@ -133,21 +133,18 @@
      :as   opts}]
    [:div
     (for [[year year-of-logs] (logbook-year-stats logbook)
-          :let [
-                max-log     (apply max-key :hour-sum year-of-logs) ;; Don't need this yet.
+          :let [max-log     (apply max-key :hour-sum year-of-logs) ;; Don't need this yet.
                 ;; This should be measured against the height and whatever the max-log is.
                 g-multiplier (/ height 8) ;; 8 - max hours we expect someone to log in a day
                 fmt-points  #(str %1 "," (* g-multiplier (%2 :hour-sum)))
                 points      (s/join " " (->> year-of-logs (map-indexed fmt-points)))]]
 
-
       [:div
        [:h5.firn-headline.firn-headline-5 year]
-       [:svg {:viewbox (format "0 0 %s %s" width height),
+       [:svg {:viewbox (format "0 0 %s %s" width height)
               :class   "chart"}
         [:g {:transform (format "translate(0, %s) scale(1, -1)", (- height (* stroke-width 1.25)))}
-         [:polyline {:fill         "none",
-                     :stroke       stroke,
-                     :stroke-width "1",
+         [:polyline {:fill         "none"
+                     :stroke       stroke
+                     :stroke-width "1"
                      :points points}]]]])]))
-

--- a/clojure/test/firn/markup_test.clj
+++ b/clojure/test/firn/markup_test.clj
@@ -43,3 +43,10 @@
   (t/testing "internal-link"
     (t/is (= (sut/link->html (sample-links :file-link))
              [:a.firn_internal {:href "./file2"} "File 2"]))))
+
+(t/deftest internal-link-handler
+  (t/testing "Expected results."
+    (let [res1 (sut/internal-link-handler "file:foo.org")
+          res2 (sut/internal-link-handler "file:foo.org::*my headline link")]
+      (t/is (= res1 "./foo"))
+      (t/is (= res2 "./foo#my-headline-link")))))

--- a/clojure/test/firn/org_test.clj
+++ b/clojure/test/firn/org_test.clj
@@ -23,6 +23,28 @@
     (t/testing "It returns the expected value."
       (t/is (= (-> res :children first :type) "section")))))
 
+(t/deftest get-headline-helper
+  (t/testing "expected output"
+    (let [sample-data
+          {:type "headline",
+           :level 1,
+           :children
+           [{:type "title", :level 1, :tags ["ATTACH"], :raw "Image Tests", :children [{:type "text", :value "Image Tests"}]}]}
+
+          sample-data-with-multiple-children
+          {:type "headline",
+           :level 1,
+           :children
+           [{:type "title", :level 1, :raw "Headlines <2020-03-27 Fri>", :properties {:foo "bar"},
+             :children [{:type "text", :value "Headlines "} {:type "timestamp", :timestamp_type "active", :start {:year 2020, :month 3, :day 27, :dayname "Fri"}}]}]}
+
+          res1 (sut/get-headline-helper sample-data)
+          res2 (sut/get-headline-helper sample-data-with-multiple-children)]
+
+      (t/is (= res1 "Image Tests"))
+      (t/is (= res2 "Headlines")))))
+
+
 (t/deftest parsed-org-date->unix-time
   (t/testing "returns the expected value."
     (t/is (= 1585683360000


### PR DESCRIPTION
Add: empty footnote ref/def classes.
Add: add sluggified id's to headlines.
Fix: add code child to get-headline-helper.
Test: get-headline-helper.