### PR TITLE
Feat: custom pages

### DIFF
--- a/clojure/resources/firn/_firn_starter/config.edn
+++ b/clojure/resources/firn/_firn_starter/config.edn
@@ -5,4 +5,5 @@
  :ignored-dirs     ["priv"] ; Directories to ignore org files in.
  :site-desc        ""       ; Used for RSS.
  :site-title       ""       ; Used for RSS.
- :site-url         ""}
+ :site-url         ""
+ :site-map-pages?   true}

--- a/clojure/resources/firn/_firn_starter/config.edn
+++ b/clojure/resources/firn/_firn_starter/config.edn
@@ -5,5 +5,5 @@
  :ignored-dirs     ["priv"] ; Directories to ignore org files in.
  :site-desc        ""       ; Used for RSS.
  :site-title       ""       ; Used for RSS.
- :site-url         ""
- :site-map-pages?   true}
+ :site-url         ""       ; Used for RSS.
+ :site-map-pages?   true}   ; if true, custom pages in the pages/ dir will show in the site-map.

--- a/clojure/resources/firn/_firn_starter/pages/tags.clj
+++ b/clojure/resources/firn/_firn_starter/pages/tags.clj
@@ -1,0 +1,3 @@
+(defn tags
+  []
+  [:h1 "Tags"])

--- a/clojure/src/firn/build.clj
+++ b/clojure/src/firn/build.clj
@@ -182,6 +182,7 @@
                   :site-map   site-map
                   :site-links site-links
                   :site-logs  site-logs
+                  :site-tags  [] ; TODO: collect tags; site-tags
                   :config     config}]
 
     (doseq [[k f] pages

--- a/clojure/src/firn/config.clj
+++ b/clojure/src/firn/config.clj
@@ -23,15 +23,17 @@
      :dir-firn        (make-dir-firn dir-files) ; the _firn root folder.
      :dir-layouts     (mdp "/layouts/")         ; where layouts are stored.
      :dir-partials    (mdp "/partials/")        ; where partials are stored.
+     :dir-pages       (mdp "/pages/")           ; where pages are stored (tags.clj, user pages, etc)
      :dir-site        (mdp "/_site/")           ; the root dir of the compiled firn site.
      :dir-site-data   dir-site-data             ; _site data folder output.
      :dir-site-static (mdp "/_site/static/")    ; _site static output for dir-static.
      :dir-static      (mdp "/static/")          ; static folder for css/js
      :dirname-files   parent-dir-name           ; the name of directory where firn is run.
-     :layouts         {}                        ; layouts loaded into memory
+     :layouts         {}                        ; layouts loaded into memory - ie, org -> clj -> html
+     :pages           {}                        ; layouts sans org-mode files - ie, clj -> html
      :org-files       []                        ; a list of org files, fetched when running setup.
      :user-config     {}                        ; user's config.edn values.
-     :partials        {}}))                        ; partials loaded into memory
+     :partials        {}}))                     ; partials loaded into memory
 
 
 ;; Values that a user can contribute/change via their config.edn

--- a/clojure/src/firn/file.clj
+++ b/clojure/src/firn/file.clj
@@ -42,13 +42,16 @@
 (defn read-clj
   "Reads a folder full of clj files, such as partials or layouts.
   pass a symbol for dir to request a specific folder."
-  [dir {:keys [dir-partials dir-layouts]}]
+  [dir {:keys [dir-partials dir-layouts dir-pages]}]
   (case dir
     :layouts
     (-> dir-layouts (u/find-files-by-ext "clj") (u/load-fns-into-map))
 
     :partials
     (-> dir-partials (u/find-files-by-ext "clj") (u/load-fns-into-map))
+
+    :pages
+    (-> dir-pages (u/find-files-by-ext "clj") (u/load-fns-into-map))
 
     (throw (Exception. "Ensure you are passing the right possible keywords to read-clj."))))
 

--- a/clojure/src/firn/file.clj
+++ b/clojure/src/firn/file.clj
@@ -59,7 +59,7 @@
   "Creates a file; which is to say, a map of data & metadata about an org-file."
   [config io-file]
   (let [name     (get-io-name io-file)
-        path-abs (.getPath ^java.io.File io-file) ; (-> io-file ^java.io.File .getPath)
+        path-abs (.getPath ^java.io.File io-file)
         path-web (get-web-path (config :dirname-files) path-abs)]
     {:as-edn    nil      ; JSON of org file -> converted to a map.
      :as-html   nil      ; the html output

--- a/clojure/src/firn/layout.clj
+++ b/clojure/src/firn/layout.clj
@@ -20,8 +20,6 @@
     [:div (render :toc)]
     [:div (render :file)]]])
 
-
-
 (defn get-layout
   "Checks if a layout for a project exists in the config map
   If it does, return the function value of the layout, otherwise the default template "
@@ -96,7 +94,6 @@
                 <br> opts:  => " opts " <code> << is this a valid value? </code>"
             "<br></div> "
             "</div>")))))
-
 
 (defn prepare
   "Prepare functions and data to be available in layout functions.

--- a/clojure/src/firn/util.clj
+++ b/clojure/src/firn/util.clj
@@ -91,6 +91,17 @@
   [io-file]
   (-> io-file file-name-no-ext (snake->kebab :key-it)))
 
+(defn keyword->web-path
+  [kw]
+  (str "/" (name kw)))
+
+(defn keyword->normal-text
+  [kw]
+  (-> kw name
+     (s/replace #"-" " ")
+     (s/replace #"_" " ")
+     (s/capitalize)))
+
 ;; File Path fns ----
 ;; Mostly for operating on paths: `file/paths/woo/hoo.org`
 

--- a/docs/_firn/config.edn
+++ b/docs/_firn/config.edn
@@ -5,4 +5,5 @@
  :ignored-dirs     ["priv"] ; Directories to ignore org files in.
  :site-desc        ""       ; Used for RSS.
  :site-title       ""       ; Used for RSS.
- :site-url         ""}
+ :site-url         ""
+ :site-map-pages?   true}

--- a/docs/_firn/pages/tags.clj
+++ b/docs/_firn/pages/tags.clj
@@ -10,7 +10,7 @@
     (map #(vector :div.pb1 [:a {:href (% :path)} (% :title)]))))
 
 (defn tags
-  [{:keys [site-map partials]}]
+  [{:keys [site-map site-links partials]}]
   (let [{:keys [head nav footer]} partials]
     (head
      [:body
@@ -20,4 +20,6 @@
         [:aside#sidebar.def-sidebar
          (render-site-map site-map)]
         [:div.def-content
+         [:div "This is a temporary page that will be updated in v0.0.7"]
+         ; (for [x site-map] [:div (str x)])
          (footer)]]]])))

--- a/docs/_firn/pages/tags.clj
+++ b/docs/_firn/pages/tags.clj
@@ -1,0 +1,23 @@
+;; (defn tags
+;;   [{:keys [site-tags partials]}]
+;;   [:div
+;;    [:h1 "Tags Page"]])
+
+(defn render-site-map
+  [sm]
+  (->> sm
+    (sort-by :firn-order)
+    (map #(vector :div.pb1 [:a {:href (% :path)} (% :title)]))))
+
+(defn tags
+  [{:keys [site-map partials]}]
+  (let [{:keys [head nav footer]} partials]
+    (head
+     [:body
+      (nav)
+      [:main
+       [:article.def-wrapper
+        [:aside#sidebar.def-sidebar
+         (render-site-map site-map)]
+        [:div.def-content
+         (footer)]]]])))

--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -1,5 +1,5 @@
 #+TITLE: Configuration
-#+FIRN_ORDER: 5
+#+FIRN_ORDER: 1
 
 * Overview
 
@@ -63,6 +63,7 @@ The firn table of contents is rendered in a layout. If you use the default layou
 | =:site-desc=        | string  | The description of your site, used for RSS.            |
 | =:site-title=       | string  | The title of your site, used for RSS.                  |
 | =:site-url=         | string  | The root url of your site.                             |
+| =:site-map-pages?=  | boolean | Whether to include custom pages in your site-map       |
 
 ** Per-file configuration
 

--- a/docs/data-and-metadata.org
+++ b/docs/data-and-metadata.org
@@ -3,7 +3,7 @@
 #+DATE_UPDATED: <2020-06-24 15:59>
 #+FILE_UNDER: docs
 #+FIRN_LAYOUT: docs
-#+FIRN_ORDER: 10
+#+FIRN_ORDER: 5 
 
 🚧 This document is in flux as Firn's API shifts and changes. 🚧
 

--- a/docs/layout.org
+++ b/docs/layout.org
@@ -1,9 +1,9 @@
 #+TITLE: Layout
 #+DATE_CREATED: <2020-03-24 Tue>
-#+DATE_UPDATED: <2020-06-24 16:23>
+#+DATE_UPDATED: <2020-07-03 18:21>
 #+FILE_UNDER: docs
 #+FIRN_LAYOUT: docs
-#+FIRN_ORDER: 1
+#+FIRN_ORDER: 2
 
 * Overview
 
@@ -196,23 +196,23 @@ There are several ways you can create table of contents in your files, from simp
 
 The following keys are made available in your layouts.
 
-| Function/Data | Intent                                               | Data-type |
-|---------------+------------------------------------------------------+-----------|
-| config        | The site wide config.                                | map       |
-| date-created  | The #+DATE_CREATED value of the file                 | string    |
-| date-updated  | The #+DATE_UPDATED value of the file                 | string    |
-| file          | The file as a data structure.                        | map       |
-| file-links    | A list of links per file                             | list      |
-| firn-under    | The #+FIRN_UNDER value of the file                   | string    |
-| logbook       | A list of logbooks entries per file.                 | list      |
-| logbook-total | The sum of all the logbook entries per file          | string    |
-| meta          | A map of metadata per file (logbook, links, etc)     | map       |
-| partials      | a list of invokable partials in your =partials= folder | list      |
-| render        | Enables rendering parts or entirety of an org file.  | function  |
-| site-links    | A list of all links across all documents             | vector    |
-| site-logs     | A list of aLL logbook entries.                       | vector    |
-| site-map      | A list of all files on the wiki                      | vector    |
-| title         | The #+TITLE value of the file.                       | string    |
+| Function/Data | Intent                                              | Data-type |
+|---------------+-----------------------------------------------------+-----------|
+| config        | The site wide config.                               | map       |
+| date-created  | The #+DATE_CREATED value of the file                | string    |
+| date-updated  | The #+DATE_UPDATED value of the file                | string    |
+| file          | The file as a data structure.                       | map       |
+| file-links    | A list of links per file                            | list      |
+| firn-under    | The #+FIRN_UNDER value of the file                  | string    |
+| logbook       | A list of logbooks entries per file.                | list      |
+| logbook-total | The sum of all the logbook entries per file         | string    |
+| meta          | A map of metadata per file (logbook, links, etc)    | map       |
+| partials      | a list of invokable partials =/partials= dir          | list      |
+| render        | Enables rendering parts or entirety of an org file. | function  |
+| site-links    | A list of all links across all documents            | vector    |
+| site-logs     | A list of aLL logbook entries.                      | vector    |
+| site-map      | A list of all files on the wiki                     | vector    |
+| title         | The #+TITLE value of the file.                      | string    |
 
 This may seem like a lot of information to make available to a layout template.
 And that's because it is. But thanks to destructuring in Clojure, you can make

--- a/docs/limitations.org
+++ b/docs/limitations.org
@@ -1,7 +1,7 @@
 #+TITLE: Limitations
 #+DATE_CREATED: <2020-03-27 Fri>
-#+DATE_UPDATED: <2020-06-24 15:58>
-#+FIRN_ORDER: 11
+#+DATE_UPDATED: <2020-07-03 18:22>
+#+FIRN_ORDER: 6 
 
 * Development Server
 

--- a/docs/pages.org
+++ b/docs/pages.org
@@ -1,6 +1,6 @@
 #+TITLE: Custom Pages
 #+DATE_CREATED: <2020-03-24 Tue>
-#+DATE_UPDATED: <2020-07-03 18:32>
+#+DATE_UPDATED: <2020-07-03 18:35>
 #+FILE_UNDER: docs
 #+FIRN_LAYOUT: docs
 #+FIRN_ORDER: 3
@@ -28,6 +28,7 @@ Pages have less data available to them at site-generation time. Because there ar
 | site-map      | A list of all files on the wiki            | vector    |
 * Limitations
 
+** Metadata
 Custom pages will not sort in the site-map. Site-map metadata, such as the =firn-order=, or =firn-under= values enable to sort and group your site-map as you like. This data is gathered from org-mode keywords. Because custom pages in the =/pages= directory do not have this metadata available, they are rendered with a pre-configured set of metadata as so:
 
 #+BEGIN_SRC clojure
@@ -36,3 +37,6 @@ Custom pages will not sort in the site-map. Site-map metadata, such as the =firn
  :firn-order 9999               ; pages will auto group at at the end of the site-map
  :firn-under "Page"})))         ; pages are grouped under "Pages"
 #+END_SRC
+** Flat routing
+
+Currently, Firn only supports creating custom pages at the root level of =/pages= - unlike org-mode files, if you have a directory within the =/pages= directory, it will not translate to a nested url. For example, if you have the file =/pages/my-category/my-custom-page-1.clj= - it will be translated into an html file named =my-custom-page-1.html= at the root of your site url.

--- a/docs/pages.org
+++ b/docs/pages.org
@@ -1,0 +1,28 @@
+#+TITLE: Custom Pages
+#+DATE_CREATED: <2020-03-24 Tue>
+#+DATE_UPDATED: <2020-07-03 18:23>
+#+FILE_UNDER: docs
+#+FIRN_LAYOUT: docs
+#+FIRN_ORDER: 3
+
+* Overview
+
+Similar to [[file:layout.org][layouts]], on creating a Firn site, you will find a folder: =_firn/pages=. This folder enables users to create custom pages that are converted from the template language (hiccup) into HTML. This is useful if you want to create a page that does not render any org-mode content.
+
+* TODO Tags - an out of the box page.
+
+The following will be available in v0.0.7
+
+Creating a new firn site comes with a custom page: =tags.clj=. This file exists to provide an example of a custom page, as well as to give user's an out-of-the-box solution for rendering tags with Firn. When Firn processes your org-mode files, it collects all heading tags, and stores them in a Clojure vector (simply, a list). This list of tags are made available to layouts and pages - in this case, the latter, which uses it to render all the tags your org-mode content has. You can of course delete this file if you do not want to render tags.
+
+* TODO Differences from layouts
+
+Pages have less data available to them at site-generation time. Because there are no org-mode files concerned, there is no =render= function. The following content is available to a page, which like layouts, can be destructured and made available to your Clojure hiccup function.
+
+| Function/Data | Intent                                     | Data-type |
+|---------------+--------------------------------------------+-----------|
+| config        | The site wide config                       | map       |
+| partials      | a list of invokable partials =/partials= dir | list      |
+| site-links    | A list of all links across all documents   | vector    |
+| site-logs     | A list of all logbook entries              | vector    |
+| site-map      | A list of all files on the wiki            | vector    |

--- a/docs/pages.org
+++ b/docs/pages.org
@@ -1,6 +1,6 @@
 #+TITLE: Custom Pages
 #+DATE_CREATED: <2020-03-24 Tue>
-#+DATE_UPDATED: <2020-07-03 18:23>
+#+DATE_UPDATED: <2020-07-03 18:32>
 #+FILE_UNDER: docs
 #+FIRN_LAYOUT: docs
 #+FIRN_ORDER: 3
@@ -26,3 +26,13 @@ Pages have less data available to them at site-generation time. Because there ar
 | site-links    | A list of all links across all documents   | vector    |
 | site-logs     | A list of all logbook entries              | vector    |
 | site-map      | A list of all files on the wiki            | vector    |
+* Limitations
+
+Custom pages will not sort in the site-map. Site-map metadata, such as the =firn-order=, or =firn-under= values enable to sort and group your site-map as you like. This data is gathered from org-mode keywords. Because custom pages in the =/pages= directory do not have this metadata available, they are rendered with a pre-configured set of metadata as so:
+
+#+BEGIN_SRC clojure
+{:path       "/<the-file-name>" ; the file path must have no spaces, and will become the web path
+ :title      "The file name"    ; the file path is converted into a sentence cased value
+ :firn-order 9999               ; pages will auto group at at the end of the site-map
+ :firn-under "Page"})))         ; pages are grouped under "Pages"
+#+END_SRC

--- a/docs/sample-page.org
+++ b/docs/sample-page.org
@@ -1,7 +1,7 @@
 #+TITLE: Sample Page
 #+FIRN_LAYOUT: sample-page
 #+FIRN_PROPERTIES?: true
-#+FIRN_ORDER: 12
+#+FIRN_ORDER: 7 
 
 * Example content
 

--- a/docs/setup.org
+++ b/docs/setup.org
@@ -1,9 +1,9 @@
 #+TITLE: Firn Setup (with Emacs)
 #+DATE_CREATED: <2020-03-27 Fri>
-#+DATE_UPDATED: <2020-06-24 16:19>
+#+DATE_UPDATED: <2020-07-03 18:22>
 #+FILE_UNDER: docs
 #+FIRN_LAYOUT: docs
-#+FIRN_ORDER: 3
+#+FIRN_ORDER: 4
 
 
 The following are notes on how to best setup Emacs and your folder of org-files


### PR DESCRIPTION
- enable user's to create custom pages in just hiccup - no org-mode content
- update documentation to reflect ☝️ 
- stub a "tags" page for displaying user's tags across headings. 