### PR TITLE
Fix: add site title, author, and description to layouts

### DIFF
--- a/clojure/resources/firn/_firn_starter/config.edn
+++ b/clojure/resources/firn/_firn_starter/config.edn
@@ -5,7 +5,8 @@
  :firn-toc         nil      ; global: settings for any rendered table of contents
  :ignored-dirs     ["priv"] ; Directories to ignore org files in.
  :run-build-clean? "never"  ; Whether to clean out unused attachments on build. Values: "never" | "always" | "prompt"
- :site-desc        ""       ; Used for RSS.
- :site-title       ""       ; Used for RSS.
+ :site-author      ""       ; Used for SEO.
+ :site-desc        ""       ; Used for RSS and SEO.
+ :site-title       ""       ; Used for RSS and SEO.
  :org-tags-path    "tags"   ; Path on which to structure links for org headline tags.
  :site-url         ""}       ; Used for building links / accessing site url in layouts/partials. If Left blank, internal links will start with `/`

--- a/clojure/resources/firn/_firn_starter/layouts/default.clj
+++ b/clojure/resources/firn/_firn_starter/layouts/default.clj
@@ -1,8 +1,8 @@
 (defn default
-  [{:keys [render partials build-url]}]
+  [{:keys [render partials build-url site-title site-author site-desc] :as config}]
   (let [{:keys [head]} partials]
     [:html
-     (head build-url)
+     (head config)
      [:body
       [:main
        [:article.content

--- a/clojure/resources/firn/_firn_starter/partials/head.clj
+++ b/clojure/resources/firn/_firn_starter/partials/head.clj
@@ -1,7 +1,10 @@
 (defn head
-  [build-url]
+  [{:keys [build-url site-title site-author site-desc]}]
   [:html
    [:head
-    [:meta {:charset "UTF-8"}]
+    [:meta {:charset "utf-8"}]
     [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
+    [:meta {:name "author" :content site-author}]
+    [:meta {:name "description" :content site-desc}]
+    [:title site-title]
     [:link {:rel "stylesheet" :href (build-url "/static/css/firn_base.css")}]]])

--- a/clojure/src/firn/layout.clj
+++ b/clojure/src/firn/layout.clj
@@ -160,6 +160,9 @@
      :site-map      (config :site-map)
      :site-links    (config :site-links)
      :site-logs     (config :site-logs)
+     :site-title    (-> config :user-config :site-title)
+     :site-author   (-> config :user-config :site-author)
+     :site-desc     (-> config :user-config :site-desc)
      :site-url      site-url
      :org-tags      (config :org-tags)
      :firn-tags     (config :firn-tags)

--- a/docs/data-and-metadata.org
+++ b/docs/data-and-metadata.org
@@ -1,6 +1,6 @@
 #+TITLE: Data and Metadata
 #+DATE_CREATED: <2020-03-25 Wed>
-#+DATE_UPDATED: <2020-09-23 18:43>
+#+DATE_UPDATED: <2020-09-29 22:26>
 #+FIRN_UNDER: Content
 #+FIRN_LAYOUT: docs
 #+FIRN_ORDER: 20
@@ -25,29 +25,32 @@ you need more fine grained control of your data.
 
 * Metadata
 
-The following table describes all the data and functions  "passed" to a layout each time a layout is applied to the data representing an org file. If the [[file:the-render-function.org][render function]] already does everything you need in your layouts, then this section may not be valuable for you.
-
+The following table describes all the data and functions "passed" to a layout each time a layout is applied to the data representing an org file. If the [[file:the-render-function.org][render function]] already does everything you need in your layouts, then this section may not be valuable for you.
 
 | Function/Data | Intent                                                | Data-type |
 |---------------+-------------------------------------------------------+-----------|
-| config        | The site wide config, containing everything!          | map       |
 | build-url     | Function to more easily construct internal urls       | function  |
-| date-created  | The ~#+DATE_CREATED~ value of the processed file        | string    |
-| date-updated  | The ~#+DATE_UPDATED~ value of the processed file        | string    |
+| config        | The site wide config, containing everything!          | map       |
+| date-created  | The ~#+DATE_CREATED~ value of the processed file      | string    |
+| date-updated  | The ~#+DATE_UPDATED~ value of the processed file      | string    |
 | file          | The file as a data structure                          | map       |
 | file-links    | A list of links per file                              | list      |
-| firn-under    | The ~#+FIRN_UNDER~ value of the file                    | string    |
-| firn-tags     | A map of tag names mapped to files.                   |           |
+| firn-tags     | A map of tag names mapped to files.                   | map       |
+| firn-under    | The ~#+FIRN_UNDER~ value of the file                  | string    |
 | logbook       | A list of logbook entries of the processed-file.      | list      |
 | logbook-total | The sum of all the logbook entries per file           | string    |
 | meta          | A map of metadata per file (logbook, links, keywords) | map       |
 | org-tags      | A map of or org tags and associated headlines.        | map       |
-| partials      | a list of invokable partials from the =/partials= dir   | list      |
+| partials      | a list of invokable partials from the =/partials= dir | list      |
 | render        | See the [[file:the-render-function.org][Render Function document]]                      | function  |
+| site-author   | The site author used for SEO.                         | string    |
+| site-desc     | The site description used for RSS and SEO.            | string    |
 | site-links    | A list of all links across all documents              | vector    |
 | site-logs     | A list of all logbook entries                         | vector    |
-| site-map      | A map of all files as sorted by ~#+FIRN_UNDER~          | map       |
-| title         | The ~#+TITLE~ value of the file.                        | string    |
+| site-map      | A map of all files as sorted by ~#+FIRN_UNDER~        | map       |
+| site-title    | The site title used for RSS and SEO.                  | string    |
+| site-url      | The site url used to build link in templates.         | string    |
+| title         | The ~#+TITLE~ value of the file.                      | string    |
 
 This may seem like a lot of information to make available to a layout template.
 And that's because it is! But thanks to destructuring in Clojure, you can make


### PR DESCRIPTION
- Add site-title site-author, and site-desc to layouts public-api
- Update default layout
- Update head partial
- Update meta data table docs
- Make meta charset casing consistent with other attributes

Hey @teesloane, I noticed that there is no site title or meta author and description. Can they be added for SEO and accessibility?

https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#Adding_an_author_and_description

I haven't been able to get my development env working yet with GraalVM to test these changes, but I wanted to check first before I go any further in case you had other plans. 