### PR TITLE
Fix: remove firn.org circular dependency

### DIFF
--- a/clojure/src/firn/org.clj
+++ b/clojure/src/firn/org.clj
@@ -4,10 +4,8 @@
   Which are created by the rust binary."
   (:require [clojure.java.shell :as sh]
             [clojure.string :as s]
-            [firn.util :as u]
-            [firn.org :as org])
-  (:import iceshelf.clojure.rust.ClojureRust)
-  (:import (java.time LocalDate)))
+            [firn.util :as u])
+  (:import iceshelf.clojure.rust.ClojureRust))
 
 (defn parse!
   "Parse the org-mode file-string.


### PR DESCRIPTION
Fix: remove firn.org circular dependency

<img width="841" alt="Screen Shot 2020-09-30 at 11 13 31 PM" src="https://user-images.githubusercontent.com/16216104/94807170-44a07200-03bd-11eb-9709-ba01368a1110.png">

- Remove unused LocalDate import