### PR TITLE
Docs: proofread docs

### DIFF
--- a/docs/backlinks.org
+++ b/docs/backlinks.org
@@ -1,7 +1,7 @@
 #+TITLE: Backlinks
 #+FIRN_UNDER: Content "The Render Function"
 #+FIRN_ORDER: 4
-#+DATE_UPDATED: <2020-09-25 19:06>
+#+DATE_UPDATED: <2020-10-19 07:50>
 #+DATE_CREATED: <2020-09-20 Sun 19:05>
 
 
@@ -22,10 +22,10 @@ A document has backlinks if an org-mode file links to another org-mode file usin
 (render :backlinks)
 #+END_SRC
 
-The above will render a list of backlinks. However, you may want to check first /if/ backlinks exist. The below code samples creates a backlinks section, with a bit of styling and a headline to indicate the sections intent:
+The above will render a list of backlinks. However, you may want to check first /if/ backlinks exist. The below code samples creates a backlinks section, with a bit of styling and a headline to indicate the section's intent:
 
 #+BEGIN_SRC clojure
-(when-let [backlinks (render :backlinks)] ; if backlinks exist, store them in a let bindings.
+(when-let [backlinks (render :backlinks)] ; if backlinks exist, store them in a let binding.
   [:div
    [:hr]
    [:div.backlinks

--- a/docs/breadcrumbs.org
+++ b/docs/breadcrumbs.org
@@ -1,7 +1,7 @@
 #+TITLE: Breadcrumbs
 #+FIRN_UNDER: Content "The Render Function"
 #+FIRN_ORDER: 9
-#+DATE_UPDATED: <2020-09-25 19:08>
+#+DATE_UPDATED: <2020-10-19 07:52>
 #+DATE_CREATED: <2020-09-20 Sun 17:10>
 
 *Purpose:* This document explains how to render *breadcrumbs* in your Firn layouts.
@@ -10,7 +10,7 @@
 
 * Overview
 
-/Breadcrumbs/ are a navigational tool that indicate where a file falls in a parent-child heirarchy. For example, this document you are reading right now falls under a parent document ("The Render Function"), which falls under another parent document ("Content").
+/Breadcrumbs/ are a navigational tool that indicate where a file falls in a parent-child hierarchy. For example, this document you are reading right now falls under a parent document ("The Render Function"), which falls under another parent document ("Content").
 
 #+BEGIN_SRC txt
 $ Content > The Render Function > Breadcrumbs
@@ -52,4 +52,4 @@ The org document to be rendered must have a ~#+FIRN_UNDER:~ front matter; the va
 #+END_SRC
 
 
-Changes you make to the ~#+FIRN_UNDER~ keyword *also affect the sitemap*. The breadcrumbs is, in essence,  a small slice of the [[file:sitemap.org][sitemap]].
+Changes you make to the ~#+FIRN_UNDER~ keyword *also affect the sitemap*. The breadcrumbs are, in essence,  a small slice of the [[file:sitemap.org][sitemap]].

--- a/docs/content.org
+++ b/docs/content.org
@@ -1,9 +1,9 @@
 #+TITLE: Content
 #+FIRN_ORDER: 2
-#+DATE_UPDATED: <2020-09-25 19:03>
+#+DATE_UPDATED: <2020-10-19 07:55>
 #+DATE_CREATED: <2020-08-14 Fri 19:03>
 
-The content subsection handles everything to do with converting org files to html.
+The content subsection handles everything to do with converting org files to HTML.
 
 - [[file:front-matter.org][Front Matter]] - Required and optional values found at the top of each org file.
 - [[file:layout.org][Layouts & Partials]] - How to organize and present your org-mode content.

--- a/docs/data-and-metadata.org
+++ b/docs/data-and-metadata.org
@@ -1,13 +1,13 @@
 #+TITLE: Data and Metadata
 #+DATE_CREATED: <2020-03-25 Wed>
-#+DATE_UPDATED: <2020-09-29 22:26>
+#+DATE_UPDATED: <2020-10-19 08:26>
 #+FIRN_UNDER: Content
 #+FIRN_LAYOUT: docs
 #+FIRN_ORDER: 20
 
 🚧 This document is in flux as Firn's API shifts and changes. 🚧
 
-This document describe the data and metadata made available in Firn when it
+This document describes the data and metadata made available in Firn when it
 comes time to customize the rendering of your content in your [[file:layout.org][layouts]]. This is a
 more advanced topic that may require a bit of comfort with Clojure.
 
@@ -19,7 +19,7 @@ their data. The two main sections in the document provide the following:
 for end-users.
 
 *Data* - the raw data available when a file is parsed - and how to access it if
-you need more fine grained control of your data.
+you need more fine-grained control of your data.
 
 -----
 
@@ -29,8 +29,8 @@ The following table describes all the data and functions "passed" to a layout ea
 
 | Function/Data | Intent                                                | Data-type |
 |---------------+-------------------------------------------------------+-----------|
-| build-url     | Function to more easily construct internal urls       | function  |
-| config        | The site wide config, containing everything!          | map       |
+| build-url     | Function to more easily construct internal URLs       | function  |
+| config        | The site-wide config, containing everything!          | map       |
 | date-created  | The ~#+DATE_CREATED~ value of the processed file      | string    |
 | date-updated  | The ~#+DATE_UPDATED~ value of the processed file      | string    |
 | file          | The file as a data structure                          | map       |
@@ -47,9 +47,9 @@ The following table describes all the data and functions "passed" to a layout ea
 | site-desc     | The site description used for RSS and SEO.            | string    |
 | site-links    | A list of all links across all documents              | vector    |
 | site-logs     | A list of all logbook entries                         | vector    |
-| site-map      | A map of all files as sorted by ~#+FIRN_UNDER~        | map       |
+| site-map      | A map of all files sorted by ~#+FIRN_UNDER~           | map       |
 | site-title    | The site title used for RSS and SEO.                  | string    |
-| site-url      | The site url used to build link in templates.         | string    |
+| site-url      | The site URL used to build link in templates.         | string    |
 | title         | The ~#+TITLE~ value of the file.                      | string    |
 
 This may seem like a lot of information to make available to a layout template.
@@ -103,7 +103,7 @@ Org files are parsed using a parser library called [[https://github.com/PoiScrip
 serving your site, Firn sends your org-file as a string into Orgize, and gets
 back a data structure representing the contents of your file.
 
-Currently, the raw parsed output of Orgize is stored in in the =file= map under
+Currently, the raw parsed output of Orgize is stored in the =file= map under
 =:as-edn=. As per using your layouts as described in the Metadata section above,
 you can access the file map in your layouts.
 
@@ -278,6 +278,6 @@ after being parsed to JSON and converted to EDN:
 
 As you can see, lots of data. Currently, Firn is not capable of interacting with
 this data very easily while you develop your Layouts. There are tentative plans
-to include a repl, or at least the ability to =println debug= in future releases.
+to include a REPL, or at least the ability to =println debug= in future releases.
 For now, it is possible to independently use the [[https://orgize.herokuapp.com][Orgize parser online]] to see
 test results as JSON.

--- a/docs/files-and-headlines.org
+++ b/docs/files-and-headlines.org
@@ -1,11 +1,11 @@
 #+TITLE: Files And Headlines
 #+FIRN_UNDER: Content "The Render Function"
 #+FIRN_ORDER: 0
-#+DATE_UPDATED: <2020-10-14 18:13>
+#+DATE_UPDATED: <2020-10-19 08:15>
 #+DATE_CREATED: <2020-09-21 Mon 17:03>
 
 *Purpose:* This document explains how to render org-mode files in their entirety
-or select portions of a file. It also covers folding of headlines and their respective
+or select portions of a file. It also covers the folding of headlines and their respective
 content.
 
 *Prerequistes*: an understanding of [[file:the-render-function.org][The Render Function]] and how [[file:layout.org][layouts]] work.
@@ -40,4 +40,4 @@ To render an entire org-mode file:
 #+END_SRC
 ** Exclude a headline
 
-Similar to org-export, you can add the ~:noexport:~ tag to a headline. Doing so will exclude the headline and all it's children from being rendered.
+Similar to org-export, you can add the ~:noexport:~ tag to a headline. Doing so will exclude the headline and all its children from being rendered.

--- a/docs/firn_tags.org
+++ b/docs/firn_tags.org
@@ -2,16 +2,16 @@
 #+FIRN_UNDER: Content "The Render Function"
 #+FIRN_ORDER: 5
 #+DATE_CREATED: <2020-08-27 Thu>
-#+DATE_UPDATED: <2020-09-24 00:08>
+#+DATE_UPDATED: <2020-10-19 08:16>
 
 
 *Purpose:* This document explains how to organize your documents with "Firn tags"
-(file based tagging) as well as how to render a list of tags on a Firn site.
+(file-based tagging) as well as how to render a list of tags on a Firn site.
 
 *Prerequistes*: an understanding of [[file:the-render-function.org][The Render Function]],  [[file:layout.org][layouts]] and [[file:front-matter.org][front matter]].
 
 * Overview
-Firn is able to tag files using the front matter ~#+FIRN_TAGS~ or ~#+ROAM_TAGS~. Firn tags are for categorizing information on a file to file basis. Please note this is different from using org-mode tags (referred to as "org-tags" throughout this documentation.)
+Firn can tag files using the front matter ~#+FIRN_TAGS~ or ~#+ROAM_TAGS~. Firn tags are for categorizing information on a file to file basis. Please note this is different from using org-mode tags (referred to as "org-tags" throughout this documentation.)
 
 * Usage
 

--- a/docs/folding.org
+++ b/docs/folding.org
@@ -3,11 +3,11 @@
 #+FIRN_FOLD: {2 true 3 true}
 #+FIRN_ORDER: 1
 #+DATE_CREATED: <2020-09-21 Mon>
-#+DATE_UPDATED: <2020-09-25 19:05>
+#+DATE_UPDATED: <2020-10-19 08:27>
 
 
 *Purpose:* Firn has a basic implementation of headline folding, mimicking
-org-mode; this document explains how configure folding.
+org-mode; this document explains how to configure folding.
 
 *Prerequistes*: an understanding of [[file:the-render-function.org][The Render Function]], [[file:layout.org][layouts]] and [[file:front-matter.org][front matter]].
 
@@ -15,7 +15,7 @@ org-mode; this document explains how configure folding.
 
 Firn includes basic semantic HTML folding that aims to replicate org-mode
 headline folding. JavaScript is not used to accomplish folding (although this is
-certainly possible); instead Firn uses the ~details~ and ~summary~ tag to
+certainly possible); instead, Firn uses the ~details~ and ~summary~ tag to
 accomplish similar functionality.
 
 Due to how the summary and details tag work, there is some finicky styling and
@@ -53,7 +53,7 @@ In your ~config.edn~ file, add a Clojure map such as the example above under the
 ; ...
 #+END_SRC
 
-As such, *all* headlines of level 3 and and 4 will have fold-toggles and start open.
+As such, *all* headlines of level 3 and 4 will have fold-toggles and start open.
 
 ** In-layout
 
@@ -69,7 +69,7 @@ In your [[file:layout.org][layouts]], you can use the [[file:the-render-function
 
 ** Per-file
 
-Using [[file:front-matter.org][Front Matter]], you can configure folding on a per file basis. The file you are reading currently uses front matter to add folding just for this file, for example purposes.
+Using [[file:front-matter.org][Front Matter]], you can configure folding on a per-file basis. The file you are reading currently uses front matter to add folding just for this file for example purposes.
 
 The front matter of this document looks as follows:
 
@@ -80,4 +80,4 @@ The front matter of this document looks as follows:
 #+END_SRC
 ** Styling
 
-You may need to style your headings based on what you need from folding; css rules pertinent to folding can be found in the ~firn_base.css~ file.
+You may need to style your headings based on what you need from folding; CSS rules pertinent to folding can be found in the ~firn_base.css~ file.

--- a/docs/table-of-contents.org
+++ b/docs/table-of-contents.org
@@ -1,7 +1,7 @@
 #+TITLE: Table Of Contents
 #+FIRN_UNDER: Content "The Render Function"
 #+FIRN_ORDER: 7
-#+DATE_UPDATED: <2020-09-25 19:07>
+#+DATE_UPDATED: <2020-10-19 07:46>
 #+DATE_CREATED: <2020-09-20 Sun 07:05>
 
 *Purpose:* This document explains how to render and customize a table of contents in your Firn layouts.
@@ -18,7 +18,7 @@ Configuring your table of contents can happen on a site-wide basis (using ~confi
 
 * Usage
 
-The table of contents can be complex and customizable. The usage section will cover several examples,the first of which will demonstrate the entire api of the table of contents, and the remainder will be used to provider more specific, simpler examples.
+The table of contents can be complex and customizable. The usage section will cover several examples, the first of which will demonstrate the entire API of the table of contents, and the remainder will be used to provide more specific, simpler examples.
 
 To follow any of the examples below, you will need to be editing a [[file:layout.org][layout]] file.
 
@@ -35,7 +35,7 @@ To follow any of the examples below, you will need to be editing a [[file:layout
 
 ** Every headline
 
-To have render *every* headline in a layout add the following:
+To render *every* headline in a layout add the following:
 
 #+BEGIN_SRC clojure
 (render :toc)
@@ -43,7 +43,7 @@ To have render *every* headline in a layout add the following:
 
 ** Render only level N headings.
 
-To have render *every* headline in a layout add the following:
+To render *every* headline in a layout add the following:
 
 #+BEGIN_SRC clojure
 (render :toc {:depth 1})
@@ -66,7 +66,7 @@ If you want to exclude "Notes" and only have its child headlines rendered, do th
 
 * Overriding values with front matter
 
-The examples above demonstrate how you would setup a table of contents in a
+The examples above demonstrate how you would set up a table of contents in a
 [[file:layout.org][layout]]. If you need to customize the table of contents on a per-file basis, set
 the options map as a value to the ~#+FIRN_TOC~ front matter at the top of an org
 file.


### PR DESCRIPTION
Reading through the docs and proofreading as I go. This is as far as I got today.

Fix typos, syntax, and wording

- docs/backlinks.org
- docs/breadcrumbs.org
- docs/content.org
- docs/data-and-metadata.org
- docs/files-and-headlines.org
- docs/firn_tags.org
- docs/folding.org
- docs/table-of-contents.org