### PR TITLE
Fix head-partial

### DIFF
--- a/clojure/resources/firn/_firn_starter/pages/tags.clj
+++ b/clojure/resources/firn/_firn_starter/pages/tags.clj
@@ -1,8 +1,8 @@
 (defn tags
-  [{:keys [build-url render partials]}]
+  [{:keys [render partials build-url site-title site-author site-desc] :as config}]
   (let [{:keys [head]} partials]
     [:html
-     (head build-url)
+     (head config)
      [:body
       [:main
        [:article.def-wrapper

--- a/clojure/resources/firn/_firn_starter/partials/head.clj
+++ b/clojure/resources/firn/_firn_starter/partials/head.clj
@@ -1,10 +1,9 @@
 (defn head
   [{:keys [build-url site-title site-author site-desc]}]
-  [:html
-   [:head
-    [:meta {:charset "utf-8"}]
-    [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
-    [:meta {:name "author" :content site-author}]
-    [:meta {:name "description" :content site-desc}]
-    [:title site-title]
-    [:link {:rel "stylesheet" :href (build-url "/static/css/firn_base.css")}]]])
+  [:head
+   [:meta {:charset "utf-8"}]
+   [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
+   [:meta {:name "author" :content site-author}]
+   [:meta {:name "description" :content site-desc}]
+   [:title site-title]
+   [:link {:rel "stylesheet" :href (build-url "/static/css/firn_base.css")}]])


### PR DESCRIPTION
This PR fixes 2 things:
- builds fail for a freshly generated site because `head`-partial is passed a url instead of the config-map
- the head-partial contains an html-tag, resulting in a nested html-tag being generated.

Changes have been tested by changing the generated files. I failed building the bin locally.
EDIT: verified working (via `firn new && firn build`) using the built artifact for Mac