### PR TITLE
Pass opts to children of headline

### DIFF
--- a/clojure/src/firn/markup.clj
+++ b/clojure/src/firn/markup.clj
@@ -560,7 +560,7 @@
                            4 (heading-id+class 4)
                            5 (heading-id+class 5)
                            (heading-id+class 6))
-        make-child       #(into [%] (map to-html children))
+        make-child       #(into [%] (map (fn [child] (to-html child opts)) children))
         render-headline  [h-level
                           (when keywrd [heading-keyword (str keywrd " ")])
                           (when priority [heading-priority (str priority " ")])

--- a/clojure/test/firn/markup_test.clj
+++ b/clojure/test/firn/markup_test.clj
@@ -320,3 +320,9 @@
     (t/is (= (second-of-2020 :log-count) 1))
     (t/is (= (second-of-2020 :hour-sum) 0.18))
     (t/is (= (-> second-of-2020 :logs-raw count) 1))))
+
+(t/deftest render-headline-with-link
+  (t/testing "Uses site-url to generate file link"
+      (let [parsed-headline {:type "headline" :level 1 :children [{:type "title" :level 1 :children [{:type "link" :path "file:somefile.org" :desc "Some file"}]}]}]
+        (t/is (= "http://foo.com/somefile"
+                 (get-in (sut/to-html parsed-headline {:site-url "http://foo.com"}) [1 3 1 1 :href]))))))


### PR DESCRIPTION
My static site, which used `site-url` in config.edn to change the base path of the site e.g. `someone.github.io/some-firn-site`. When a link was used in a headline, the link would be relative to the domain, not the subdirectory. I found this behaviour could also be reproduced using a file structure like the following (with no changes to site-url):
 
```
.
├── _firn
│   ├── ...
└── test
    ├── otherthing.org
    └── thing.org
```

If `thing.org` contains:

```org
#+TITLE: A test firn page
* [[file:otherthing.org][test]]

[[file:otherthing.org][still testing]]
```

running this through a binary built on master, as well as firn v0.0.11, the link in the headline links to `/otherthing.org`, which gives a 404 page, whereas the "still testing" link under the headline works exactly as intended, linking to `/test/otherthing.org`.

Upon inspecting the code, I discovered the bug appears to arise from not passing the `opts` map down to the children of the headline when calling `to-html`, which I have attempted to resolve. I have also added a test to check that this behaves as I believe it should to catch potential future regressions. Please excuse the quality of my Clojure, it's very much not my primary language!