### PR TITLE
Using a sub-part of the generated HTML as the RSS description

### DIFF
--- a/clojure/project.clj
+++ b/clojure/project.clj
@@ -7,6 +7,7 @@
                  [cheshire "5.10.0"]
                  [clj-rss "0.2.5"]
                  [hiccup "1.0.5"]
+                 [hiccup-find "1.0.0"]
                  [http-kit "2.3.0"]
                  ;; [juxt/dirwatch "0.2.5"] ;; vendored
                  [me.raynes/fs "1.4.6"]

--- a/clojure/project.clj
+++ b/clojure/project.clj
@@ -7,7 +7,7 @@
                  [cheshire "5.10.0"]
                  [clj-rss "0.2.5"]
                  [hiccup "1.0.5"]
-                 [hiccup-find "1.0.0"]
+                 ;; [hiccup-find "1.0.0"]   ;; vendored
                  [http-kit "2.3.0"]
                  ;; [juxt/dirwatch "0.2.5"] ;; vendored
                  [me.raynes/fs "1.4.6"]

--- a/clojure/src/firn/layout.clj
+++ b/clojure/src/firn/layout.clj
@@ -184,22 +184,21 @@
      :date-created  (-> file :meta :date-created)}))
 
 (defn apply-layout
-  "If a file has a template, render the file with it, or use the default layout"
+  "If a file has a template, render the file with it, or use the default layout. Returns an Hiccup form"
   [config file layout]
-  (let [selected-layout (get-layout config file layout)]
-    (h/html
-     (let [ulm (prepare config file)
-           fn-name #(-> % meta :name)] ;; ulm => user-layout-map
-       (try
-         (selected-layout ulm)
-         (catch Exception e
-           ;; NOTE: My Hacky take on cleaning up a stack trace.
-           (u/print-err! :error
-                         (str "A layout function <" (fn-name selected-layout) "> failed when parsing <" (ulm :title) ">")
-                         (str "\nThe Small Clojure Interpreter found this error:\n")
-                         (let [er (Throwable->map e)
-                               sci-err (-> er :via first :data) ]
-                           (str
-                            "\n  | Cause: " (sci-err :message)
-                            "\n  | Layout Function: "  (fn-name selected-layout)
-                            "\n")))))))))
+  (let [selected-layout (get-layout config file layout)
+        ulm (prepare config file)
+        fn-name #(-> % meta :name)]
+    (try
+      (selected-layout ulm)
+      (catch Exception e
+        ;; NOTE: My Hacky take on cleaning up a stack trace.
+        (u/print-err! :error
+                      (str "A layout function <" (fn-name selected-layout) "> failed when parsing <" (ulm :title) ">")
+                      (str "\nThe Small Clojure Interpreter found this error:\n")
+                      (let [er (Throwable->map e)
+                            sci-err (-> er :via first :data) ]
+                        (str
+                         "\n  | Cause: " (sci-err :message)
+                         "\n  | Layout Function: "  (fn-name selected-layout)
+                         "\n")))))))

--- a/clojure/src/hiccup_find/core.cljc
+++ b/clojure/src/hiccup_find/core.cljc
@@ -1,0 +1,102 @@
+;; Copyright © 2014-2018, Christian Johansen, Magnar Sveen, and Ian Truslove.
+;;
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file LICENSE at the root of this distribution.
+;;
+;; By using this software in any fashion, you are agreeing to be bound by the
+;; terms of this license.
+;;
+;; You must not remove this notice, or any other, from this software.
+(ns hiccup-find.core
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.walk :refer [postwalk]]))
+
+(defn hiccup-tree [tree]
+  (tree-seq #(or (vector? %) (seq? %)) seq tree))
+
+(defn hiccup-nodes
+  "Takes a hiccup tree and returns a list of all the nodes in it.
+
+[:html
+ [:body
+  '([:p \"Hey\"]
+    [:p \"There\"])]]
+
+turns into
+
+([:html [:body '([:p \"Hey\"] [:p \"There\"])]]
+ [:body '([:p \"Hey\"] [:p \"There\"])]
+ [:p \"Hey\"]
+ [:p \"There\"])"
+  [root]
+  (->> root
+       hiccup-tree
+       (filter vector?)))
+
+(defn split-hiccup-symbol
+  "Split the hiccup 'tag name' symbol into the tag name, class names and id"
+  [symbol]
+  (re-seq #"[:.#][^:.#]+" (str symbol)))
+
+(defn split-hiccup-form [form]
+  (if (map? (second form))
+    (concat (split-hiccup-symbol (first form))
+            (when-let [class (-> form second :class)]
+              (map #(str "." %) (str/split class #" ")))
+            [(str "#" (-> form second :id))])
+    (split-hiccup-symbol (first form))))
+
+(defn hiccup-symbol-matches?
+  "Determine if a query matches a single hiccup node symbol"
+  [q symbol]
+  (set/subset? (set (split-hiccup-symbol q))
+               (set (split-hiccup-symbol symbol))))
+
+(defn hiccup-form-matches?
+  "Determine if a query matches a single hiccup node symbol"
+  [q form]
+  (set/subset? (set (split-hiccup-symbol q))
+               (into #{} (split-hiccup-form form))))
+
+(defn hiccup-find
+  "Return the node from the hiccup document matching the query, if any.
+   The query is a vector of hiccup symbols; keywords naming tag names, classes
+   and ids (either one or a combination) like :tag.class.class2#id"
+  [query root]
+  (if (and (seq root) (seq query))
+    (recur (rest query)
+           (->> (hiccup-nodes root)
+                (filter #(hiccup-form-matches? (first query) %))))
+    root))
+
+(def inline-elements
+  #{:b :big :i :small :tt :abbr :acronym :cite :code :dfn :em :kbd
+    :strong :samp :var :a :bdo :br :img :map :object :q :script
+    :span :sub :sup :button :input :label :select :textarea})
+
+(defn inline? [node]
+  (and (vector? node) (contains? inline-elements (first node))))
+
+(defn hiccup-text
+  "Return only text from the hiccup structure; remove
+   all tags and attributes"
+  [tree]
+  (->> (hiccup-tree tree)
+       (reduce (fn [text node]
+                 (cond
+                  (inline? node) text
+                  (vector? node) (str/replace text #"(.+)\n?$" #(str (second %1) "\n"))
+                  (string? node) (str text node)
+                  (number? node) (str text node)
+                  :else text)) "")))
+
+(defn hiccup-string
+  "Return the hiccup-text as a one-line string; removes newlines and collapses
+   multiple spaces."
+  [tree]
+  (-> tree
+      hiccup-text
+      (str/replace #"\n" " ")
+      (str/replace #"\s+" " ")))


### PR DESCRIPTION
Hi,

As discussed in the issue #89, I implemented a way to avoid the use of the whole HTML content of an article as the `<description>` of an article in the RSS feed.xml file.

Note : Instead of using the  `[:main]` tag as suggested by @teesloane in the issue, I extracted the first `[:article.rss]`.
It is discussable, but I think it fits well the semantic of a RSS article. Indeed, the main tag can contain other 'article-unrelated' nodes.
This is a breaking change for users that are currently using RSS.

Waiting for your opinion on this.