### PR TITLE
Refactor link transforming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-orgize = { version = "0.9.0", features = ["chrono"]}
+orgize = { version = "0.9.0", features = ["chrono", "syntect"]}
 tera = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.48"
@@ -19,7 +19,6 @@ chrono = "0.4"
 slugify = "0.1.0"
 sass-rs = "0.2"
 # for server (borrowed from zola)
-# hyper = { version = "0.14.1", default-features = false, features = ["runtime", "server", "http2", "http1"] }
 tokio = { version = "1.0.1", default-features = false, features = ["rt", "fs", "full"] }
 warp = "0.3"
 notify = "4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,21 @@ use std::process::Command;
 use std::{collections::HashMap, fs::create_dir_all};
 use tera;
 
+#[derive(Debug, Clone)]
+pub struct BaseUrl {
+    pub base_url: String,
+    dir_source: PathBuf,
+}
+
+impl BaseUrl {
+    pub fn new(base_url: String, dir_source: PathBuf) -> BaseUrl {
+        BaseUrl {
+            base_url,
+            dir_source,
+        }
+    }
+}
+
 pub struct Config<'a> {
     pub dir_source: PathBuf,
     pub dir_firn: PathBuf,
@@ -50,7 +65,7 @@ pub struct Config<'a> {
     pub tag_page: PathBuf,
     pub tags_map: HashMap<String, Vec<OrgMetadata<'a>>>,
     pub tags_list: Vec<LinkData>,
-    pub base_url: String,
+    pub base_url: BaseUrl,
 }
 
 /// Builds common paths for the config object.
@@ -82,10 +97,10 @@ impl<'a> Config<'a> {
         let tag_page = dir_firn.join("[tags].html");
 
         Ok(Config {
-            dir_source: cwd,
+            dir_source: cwd.clone(),
             global_attachments: Vec::new(),
             tera: templates::tera::load_templates(&dir_templates.clone()),
-            base_url: user_config.site.url.clone(),
+            base_url: BaseUrl::new(user_config.site.url.clone(), cwd.clone()),
             dir_static_src: dir_firn.join("static"),
             dir_static_dest: dir_firn.join("_site/static"),
             dir_sass: dir_firn.join("sass"),
@@ -288,8 +303,8 @@ impl<'a> Config<'a> {
             let x = LinkData::new(
                 tag_url,
                 tag_name.to_string(),
-                LinkMeta::Tag{count: v.len()},
-                None
+                LinkMeta::Tag { count: v.len() },
+                None,
             );
             out.push(x);
         }
@@ -310,7 +325,7 @@ impl<'a> Config<'a> {
                         sitemap_item_url,
                         v.originating_file.clone(),
                         LinkMeta::Sitemap,
-                        Some(v.front_matter.clone())
+                        Some(v.front_matter.clone()),
                     );
                     out.push(x);
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,13 +26,11 @@ use tera;
 pub struct BaseUrl {
     pub base_url: String,
     dir_source: PathBuf,
-    dir_data_files_src: PathBuf,
     dir_data_name: String,
 }
 
 impl BaseUrl {
     pub fn new(base_url: String, dir_source: PathBuf, dir_data_files_src: PathBuf) -> BaseUrl {
-        // let dir_data_name = dir_data_files_src.file_name().unwrap();
         let dir_data_name = dir_data_files_src
             .file_name()
             .map(|name| name.to_string_lossy().into_owned())
@@ -42,7 +40,6 @@ impl BaseUrl {
             base_url,
             dir_source,
             dir_data_name,
-            dir_data_files_src,
         }
     }
     // check if a link is linking to our data directory (in which case we don't
@@ -63,7 +60,6 @@ impl BaseUrl {
     pub fn build(self, link: String, file_path: PathBuf) -> String {
         let parent_dirs = self.strip_source_cwd(file_path);
         let mut link_res = PathBuf::from(self.base_url.clone());
-        println!("{:?}", parent_dirs);
         if parent_dirs != PathBuf::from("") && !self.link_starts_with_data_dir(link.clone()) {
             link_res.push(parent_dirs);
         }

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,10 +1,10 @@
+use crate::config::BaseUrl;
+use crate::util;
 use orgize::export::{DefaultHtmlHandler, HtmlEscape, HtmlHandler};
 use orgize::{elements, Element};
 use std::io::{Error as IOError, Write};
+use std::path::PathBuf;
 use std::string::FromUtf8Error;
-use crate::templates::links;
-use crate::util;
-
 
 // -- HTML Handlers for Orgize -------------------------------------------------
 
@@ -38,7 +38,6 @@ pub struct MyHtmlHandler(DefaultHtmlHandler);
 impl HtmlHandler<MyError> for MyHtmlHandler {
     fn start<W: Write>(&mut self, mut w: W, element: &Element) -> Result<(), MyError> {
         match element {
-
             Element::Document { .. } => write!(w, "<div>")?,
             Element::Title(title) => {
                 if title.level > 6 {
@@ -48,7 +47,11 @@ impl HtmlHandler<MyError> for MyHtmlHandler {
                         write!(w, "<h6 id=\"{0}\">", &title.raw)?;
                     }
                 } else if let Some(keyword) = &title.keyword {
-                    write!(w, "<h{0} class=\"firn-{2}\" id=\"{1}\">", title.level, &title.raw, keyword)?;
+                    write!(
+                        w,
+                        "<h{0} class=\"firn-{2}\" id=\"{1}\">",
+                        title.level, &title.raw, keyword
+                    )?;
                 } else {
                     write!(w, "<h{0} id=\"{1}\">", title.level, &title.raw,)?;
                 }
@@ -85,34 +88,42 @@ impl HtmlHandler<MyError> for MyHtmlHandler {
     }
 }
 
-
-// -- HTML Transformers
+// -- HTML Renderes
+//
+// There are a few cases where we iterate over the parsed orgize content
+// and then match over an orgize::Event::<title,Link, etc> and write html.
+//
+// Rather than write link/title rendering several times, we do it here.
 //
 // Before we hand off orgize-data structures to the above html handler for writing html
 // we sometimes need to transform the data based on user customization / help etc.
 // most of these need to just transfer the beginning of the html (the start fn needed by the trait.)
 
-pub fn trx_link(
+/// render_link transforms a link as orgize reads it to a happy little weblink.
+/// namely, we need to handle for prepending the baseurl, and match any sibling/parent
+/// linking when encountering a `./` or `../` type of link.
+pub fn write_link(
     link: &elements::Link,
     handler: &mut MyHtmlHandler,
     writer: &mut Vec<u8>,
-    base_url: String,
+    base_url: BaseUrl,
+    file_path: PathBuf,
 ) {
-    let link_web_path = links::link_transformer(base_url, link.path.to_owned().to_string());
+    let link_web_path =
+        util::transform_org_link_to_html(base_url, link.path.to_owned().to_string(), file_path);
     let new_link = elements::Link {
         path: std::borrow::Cow::Borrowed(&link_web_path),
         desc: link.desc.to_owned(),
     };
     let new_link_enum = Element::Link(new_link);
-     handler.start(writer, &new_link_enum).unwrap()
+    handler.start(writer, &new_link_enum).unwrap()
 }
 
-
-pub fn trx_title(
+pub fn write_title(
     title: &elements::Title,
     handler: &mut MyHtmlHandler,
     writer: &mut Vec<u8>,
-    update_level: Option<i8>
+    update_level: Option<i8>,
 ) {
     let update_level = update_level.unwrap_or(0);
     let mut new_level = title.level as i8 + update_level;

--- a/src/org.rs
+++ b/src/org.rs
@@ -139,7 +139,7 @@ impl<'a> OrgFile<'a> {
             .into_os_string()
             .into_string()
             .expect("Failed to convert web_path to string");
-        let full_url = util::make_site_url(cfg.base_url.clone(), web_path_str);
+        let full_url = cfg.base_url.clone().build(web_path_str, file_path.clone());
         let out_path = PathBuf::from(&cfg.dir_site_out).join(&web_path);
         let parsed = Org::parse_string(read_file);
         let front_matter = FrontMatter::new(&parsed);

--- a/src/org.rs
+++ b/src/org.rs
@@ -139,7 +139,7 @@ impl<'a> OrgFile<'a> {
             .into_os_string()
             .into_string()
             .expect("Failed to convert web_path to string");
-        let full_url = util::make_site_url(cfg.clone_baseurl(), web_path_str);
+        let full_url = util::make_site_url(cfg.base_url.clone(), web_path_str);
         let out_path = PathBuf::from(&cfg.dir_site_out).join(&web_path);
         let parsed = Org::parse_string(read_file);
         let front_matter = FrontMatter::new(&parsed);
@@ -373,7 +373,9 @@ impl<'a> OrgFile<'a> {
                 OrgMetadataType::Link(link) => {
                     let new_link_path = link.path.to_owned().to_string();
                     let web_link =
-                        util::org_file_link_to_html_link(cfg.clone_baseurl(), new_link_path);
+                        // util::org_file_link_to_html_link(cfg.clone_baseurl(), new_link_path, self.file_path);
+                        // TODO: find out if this stuff works still
+                        util::transform_org_link_to_html(cfg.base_url.clone(), new_link_path, self.file_path.clone());
 
                     let backlink_item_url = format!(
                         "{}/{}",

--- a/src/org.rs
+++ b/src/org.rs
@@ -373,8 +373,6 @@ impl<'a> OrgFile<'a> {
                 OrgMetadataType::Link(link) => {
                     let new_link_path = link.path.to_owned().to_string();
                     let web_link =
-                        // util::org_file_link_to_html_link(cfg.clone_baseurl(), new_link_path, self.file_path);
-                        // TODO: find out if this stuff works still
                         util::transform_org_link_to_html(cfg.base_url.clone(), new_link_path, self.file_path.clone());
 
                     let backlink_item_url = format!(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -106,7 +106,7 @@ fn detect_change_kind(dir_source: &PathBuf, path: PathBuf) -> (PathBuf, ChangeKi
         ChangeKind::Config
     // this should be at the end of the block!
     // detects if it's an org file that has changed
-    } else if let Some(parent) = changed_path.parent() {
+    } else if let Some(_parent) = changed_path.parent() {
         if let Some(extension) = changed_path.extension() {
             if  extension == "org" {
                 ChangeKind::OrgFile

--- a/src/templates/links.rs
+++ b/src/templates/links.rs
@@ -1,28 +1,28 @@
-use crate::{front_matter::FrontMatter, util};
+use crate::front_matter::FrontMatter;
 use serde::Serialize;
 
 /// Transforms the possible link *paths* we might get while parsing org links from orgize.
-pub fn link_transformer(base_url: String, org_link_path: String) -> String {
-    let mut link_path = org_link_path;
-    // <1> -- It's a local org file.
-    if util::is_local_org_file(&link_path) {
-        link_path = util::clean_file_link(link_path);
-        link_path = str::replace(&link_path, ".org", ".html");
-        return util::make_site_url(base_url, link_path);
+// pub fn link_transformer(base_url: String, org_link_path: String, file_path: PathBuf) -> String {
+//     let mut link_path = org_link_path;
+//     // <1> -- It's a local org file.
+//     if util::is_local_org_file(&link_path) {
+//         link_path = util::clean_file_link(link_path);
+//         link_path = str::replace(&link_path, ".org", ".html");
+//         return util::make_site_url(base_url, link_path);
 
-    // <2> it's a local image
-    } else if util::is_local_img_file(&link_path) {
-        link_path = util::clean_file_link(link_path);
-        return util::make_site_url(base_url, link_path);
-    }
+//     // <2> it's a local image
+//     } else if util::is_local_img_file(&link_path) {
+//         link_path = util::clean_file_link(link_path);
+//         return util::make_site_url(base_url, link_path);
+//     }
 
-    // <3> is a web link (doesn't start with baseurl.)
-    if !util::is_local_org_file(&link_path) {
-        return link_path;
-    }
-    // <4> We don't know? Just return the link.
-    link_path
-}
+//     // <3> is a web link (doesn't start with baseurl.)
+//     if !util::is_local_org_file(&link_path) {
+//         return link_path;
+//     }
+//     // <4> We don't know? Just return the link.
+//     link_path
+// }
 
 // -- Link data for Tera to loop over --------------------------------------------
 

--- a/src/templates/links.rs
+++ b/src/templates/links.rs
@@ -1,29 +1,6 @@
 use crate::front_matter::FrontMatter;
 use serde::Serialize;
 
-/// Transforms the possible link *paths* we might get while parsing org links from orgize.
-// pub fn link_transformer(base_url: String, org_link_path: String, file_path: PathBuf) -> String {
-//     let mut link_path = org_link_path;
-//     // <1> -- It's a local org file.
-//     if util::is_local_org_file(&link_path) {
-//         link_path = util::clean_file_link(link_path);
-//         link_path = str::replace(&link_path, ".org", ".html");
-//         return util::make_site_url(base_url, link_path);
-
-//     // <2> it's a local image
-//     } else if util::is_local_img_file(&link_path) {
-//         link_path = util::clean_file_link(link_path);
-//         return util::make_site_url(base_url, link_path);
-//     }
-
-//     // <3> is a web link (doesn't start with baseurl.)
-//     if !util::is_local_org_file(&link_path) {
-//         return link_path;
-//     }
-//     // <4> We don't know? Just return the link.
-//     link_path
-// }
-
 // -- Link data for Tera to loop over --------------------------------------------
 
 #[derive(Debug, PartialEq, Serialize)]

--- a/src/templates/render.rs
+++ b/src/templates/render.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::Config,
+    config::{BaseUrl, Config},
     errors::{FirnError, FirnErrorType},
     front_matter,
     html::{self, MyHtmlHandler},
@@ -16,7 +16,7 @@ use tera::{Function as TeraFn, Result as TeraResult};
 #[derive(Debug, Clone)]
 pub struct Render {
     original_org: String,
-    base_url: String,
+    base_url: BaseUrl,
     file_path: PathBuf,
     front_matter: front_matter::FrontMatter,
     verbosity: i8,
@@ -35,7 +35,7 @@ impl Render {
             original_org: o.original_org.clone(),
             front_matter: o.front_matter.clone(),
             file_path: o.file_path.clone(),
-            base_url: cfg.clone_baseurl(),
+            base_url: cfg.base_url.clone(),
             verbosity: cfg.verbosity,
             user_config: cfg.user_config.clone(),
         }
@@ -56,11 +56,15 @@ impl Render {
             match event {
                 Event::Start(el) => match el {
                     Element::Title(title) => {
-                        html::trx_title(title, &mut handler, &mut wr, update_level)
+                        html::write_title(title, &mut handler, &mut wr, update_level)
                     }
-                    Element::Link(link) => {
-                        html::trx_link(link, &mut handler, &mut wr, self.base_url.clone())
-                    }
+                    Element::Link(link) => html::write_link(
+                        link,
+                        &mut handler,
+                        &mut wr,
+                        self.base_url.clone(),
+                        self.file_path.clone(),
+                    ),
                     _ => handler.start(&mut wr, el).unwrap(),
                 },
                 Event::End(el) => handler.end(&mut wr, el).unwrap(),
@@ -93,11 +97,15 @@ impl Render {
                     if is_writing {
                         match el {
                             Element::Title(title) => {
-                                html::trx_title(title, &mut handler, &mut wr, update_level)
+                                html::write_title(title, &mut handler, &mut wr, update_level)
                             }
-                            Element::Link(link) => {
-                                html::trx_link(link, &mut handler, &mut wr, self.base_url.clone())
-                            }
+                            Element::Link(link) => html::write_link(
+                                link,
+                                &mut handler,
+                                &mut wr,
+                                self.base_url.clone(),
+                                self.file_path.clone(),
+                            ),
                             _ => handler.start(&mut wr, el).unwrap(),
                         }
                     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,5 @@
-use crate::{errors::FirnError, html::MyHtmlHandler};
+use crate::{config::BaseUrl, errors::FirnError};
 use glob::glob;
-use orgize::export::HtmlHandler;
-use orgize::{elements, Element};
 use std::path::{Path, PathBuf};
 use tera::Tera;
 
@@ -33,25 +31,80 @@ pub fn exit() -> ! {
 }
 
 // Converts a string: `file:../myorglink.org` to `<site_baseurl>/myorglink.html`
-pub fn org_file_link_to_html_link(base_url: String, org_link_path: String) -> String {
-    let mut result = clean_file_link(org_link_path);
-    result = str::replace(&result, ".org", ".html");
-    make_site_url(base_url, result)
-}
+// pub fn org_file_link_to_html_link(
+//     base_url: String,
+//     org_link_path: String,
+//     file_path: PathBuf,
+// ) -> String {
+//     let mut result = clean_file_link(org_link_path);
+//     result = str::replace(&result, ".org", ".html");
+//     make_site_url(base_url, result)
+// }
 
 // removes preceding ../../ from a file: link.
-pub fn clean_file_link(org_link_path: String) -> String {
-    let mut result = String::from("");
-    for i in org_link_path.split("../") {
-        if !i.is_empty() || i != "file:" {
-            result = i.to_string();
+// pub fn clean_file_link(org_link_path: String) -> String {
+//     let mut result = String::from("");
+//     for i in org_link_path.split("../") {
+//         if !i.is_empty() || i != "file:" {
+//             result = i.to_string();
+//         }
+//     }
+//     str::replace(&result, "file:", "")
+// }
+
+/// transform_org_link_to_html converts an org link such as:
+/// `file:../myorglink.org` to:
+/// `<site_baseurl>/myorglink.html`
+/// Has to handle:
+/// - prepending the baseurl
+/// - stripping "../../" from links.
+/// - handling links that start with "./" (ie: "sibling lings")
+/// which requires the file path of the oroginating link so we can get the parent.
+/// TODO: update baseurl to be a struct that can hold data like
+/// what is the cwd / root of the wiki, or can build links etc.
+pub fn transform_org_link_to_html(
+    base_url: BaseUrl,
+    org_link_path: String,
+    _file_path: PathBuf,
+) -> String {
+
+    let clean_file_link = |lnk: String| -> String {
+        // if it's a link up a directory...
+        let mut result = String::from("");
+        for i in lnk.split("../") {
+            if !i.is_empty() || i != "file:" {
+                result = i.to_string();
+            }
         }
+        str::replace(&result, "file:", "")
+    };
+
+    let mut link_path = org_link_path;
+
+    // -- handle different types of links.
+
+    // <1> -- It's a local org file.
+    if is_local_org_file(&link_path) {
+        link_path = clean_file_link(link_path);
+        link_path = str::replace(&link_path, ".org", ".html");
+        return make_site_url(base_url, link_path);
+
+    // <2> it's a local image
+    } else if is_local_img_file(&link_path) {
+        link_path = clean_file_link(link_path);
+        return make_site_url(base_url, link_path);
     }
-    str::replace(&result, "file:", "")
+
+    // <3> is a web link (doesn't start with baseurl.)
+    if !is_local_org_file(&link_path) {
+        return link_path;
+    }
+    // <4> We don't know? Just return the link.
+    link_path
 }
 
-pub fn make_site_url(base_url: String, link: String) -> String {
-    format!("{}/{}", base_url, link)
+pub fn make_site_url(base_url: BaseUrl, link: String) -> String {
+    format!("{}/{}", base_url.base_url, link)
 }
 
 // org link methods
@@ -92,10 +145,12 @@ pub fn is_local_img_file(s: &str) -> bool {
 // Returns the name of a template (to later render), provided it's found
 // in the tera instance.
 pub fn get_template(tera: &Tera, template: &str) -> Result<String, FirnError> {
-    
     let template_with_html = format!("{}.html", &template);
     let default_template_name = "default.html".to_string();
-    if tera.get_template_names().any(|x| x == template_with_html.as_str()) {
+    if tera
+        .get_template_names()
+        .any(|x| x == template_with_html.as_str())
+    {
         return Ok(template_with_html);
     }
     Ok(default_template_name)

--- a/src/util.rs
+++ b/src/util.rs
@@ -54,30 +54,6 @@ pub fn make_site_url(base_url: String, link: String) -> String {
     format!("{}/{}", base_url, link)
 }
 
-/// This converts a orgize link (struct) to an html link
-pub fn orgize_link_to_html_link(
-    link: &elements::Link,
-    handler: &mut MyHtmlHandler,
-    writer: &mut Vec<u8>,
-    el: &Element,
-    base_url: String,
-) {
-    let link_path = link.path.to_owned();
-    if is_local_org_file(&link_path) {
-        let link_path = link.path.to_string();
-        let result = org_file_link_to_html_link(base_url, link_path);
-        let new_link = elements::Link {
-            path: std::borrow::Cow::Borrowed(&result),
-            desc: link.desc.to_owned(),
-        };
-        let new_link_enum = Element::Link(new_link);
-
-        handler.start(writer, &new_link_enum).unwrap()
-    } else {
-        handler.start(writer, el).unwrap()
-    }
-}
-
 // org link methods
 // (mostly for doing things with links that look like:
 // `file:../`

--- a/src/util.rs
+++ b/src/util.rs
@@ -30,28 +30,6 @@ pub fn exit() -> ! {
     ::std::process::exit(1);
 }
 
-// Converts a string: `file:../myorglink.org` to `<site_baseurl>/myorglink.html`
-// pub fn org_file_link_to_html_link(
-//     base_url: String,
-//     org_link_path: String,
-//     file_path: PathBuf,
-// ) -> String {
-//     let mut result = clean_file_link(org_link_path);
-//     result = str::replace(&result, ".org", ".html");
-//     make_site_url(base_url, result)
-// }
-
-// removes preceding ../../ from a file: link.
-// pub fn clean_file_link(org_link_path: String) -> String {
-//     let mut result = String::from("");
-//     for i in org_link_path.split("../") {
-//         if !i.is_empty() || i != "file:" {
-//             result = i.to_string();
-//         }
-//     }
-//     str::replace(&result, "file:", "")
-// }
-
 /// transform_org_link_to_html converts an org link such as:
 /// `file:../myorglink.org` to:
 /// `<site_baseurl>/myorglink.html`
@@ -60,14 +38,12 @@ pub fn exit() -> ! {
 /// - stripping "../../" from links.
 /// - handling links that start with "./" (ie: "sibling lings")
 /// which requires the file path of the oroginating link so we can get the parent.
-/// TODO: update baseurl to be a struct that can hold data like
-/// what is the cwd / root of the wiki, or can build links etc.
+///
 pub fn transform_org_link_to_html(
     base_url: BaseUrl,
     org_link_path: String,
-    _file_path: PathBuf,
+    file_path: PathBuf,
 ) -> String {
-
     let clean_file_link = |lnk: String| -> String {
         // if it's a link up a directory...
         let mut result = String::from("");
@@ -87,12 +63,12 @@ pub fn transform_org_link_to_html(
     if is_local_org_file(&link_path) {
         link_path = clean_file_link(link_path);
         link_path = str::replace(&link_path, ".org", ".html");
-        return make_site_url(base_url, link_path);
+        return base_url.build(link_path, file_path);
 
     // <2> it's a local image
     } else if is_local_img_file(&link_path) {
         link_path = clean_file_link(link_path);
-        return make_site_url(base_url, link_path);
+        return base_url.build(link_path, file_path);
     }
 
     // <3> is a web link (doesn't start with baseurl.)
@@ -103,9 +79,6 @@ pub fn transform_org_link_to_html(
     link_path
 }
 
-pub fn make_site_url(base_url: BaseUrl, link: String) -> String {
-    format!("{}/{}", base_url.base_url, link)
-}
 
 // org link methods
 // (mostly for doing things with links that look like:


### PR DESCRIPTION
- refactor: make site baseurl into it's own struct.
- construct links using the baseurl struct's "build" method.
- fix:  files in a subfolder can now link to sibling files without resulting in a dead link.

if you have a file `foo/bar/my_file.org` and it has a link of `file:another_file.org`, before - this be a dead link, now, we grab the parent directories of the file that the link is found in and reconstruct the link so that `file:another_file.org` becomes :`foo/bar/another_link.html`.