### PR TITLE
refactor: add various code refactorings

### DIFF
--- a/src/new_site.rs
+++ b/src/new_site.rs
@@ -185,8 +185,8 @@ img { max-width: 600px; }
 "#;
 
 pub fn init(cwd: PathBuf) {
-    let dir_firn = PathBuf::new().join(&cwd).join("_firn");
-    if fs::metadata(dir_firn.clone()).is_ok() {
+    let dir_firn = cwd.join("_firn");
+    if fs::metadata(&dir_firn).is_ok() {
         println!("A '_firn' site already exists at this directory.")
     } else {
         let dirs = vec!["layouts/", "layouts/partials", "sass", "static/css", "static/js", "_site"];
@@ -202,7 +202,7 @@ pub fn init(cwd: PathBuf) {
         files.insert(String::from("config.yaml"), CONFIG_YAML);
 
         // Map over the above strings, turn them into paths, and create them.
-        for dir in dirs.iter() {
+        for &dir in &dirs {
             let joined_dir = dir_firn.join(dir);
             fs::create_dir_all(joined_dir).expect("Couldn't create a new firn, directory");
         }

--- a/src/templates/render.rs
+++ b/src/templates/render.rs
@@ -172,7 +172,7 @@ impl<'a> TeraFn for Render {
                 Err(_e) => {
                     if self.verbosity == 1 {
                         println!("\n⚠️ Warning: Firn could not find the headline {:?}\nfor file {:?};\nThe layout ({:?}), which is trying to render the headline will be partially empty.",
-                                 headline, self.file_path, self.front_matter.layout.clone().unwrap_or("".to_string())
+                                 headline, self.file_path, self.front_matter.layout.as_deref().unwrap_or("")
                         );
                     }
                     Ok(tera::Value::String("".to_string()))

--- a/src/templates/tera.rs
+++ b/src/templates/tera.rs
@@ -1,5 +1,5 @@
 use crate::{config::Config, org::OrgFile, templates, util};
-use std::path::PathBuf;
+use std::path::Path;
 use tera::Tera;
 
 /// setup_tera
@@ -29,7 +29,7 @@ pub fn setup(cfg: &Config, org_file: &OrgFile) -> Tera {
     tera
 }
 
-pub fn load_templates(dir_templates: &PathBuf) -> Tera {
+pub fn load_templates(dir_templates: &Path) -> Tera {
     let template_path = format!("{}/**/*.html", util::path_to_string(dir_templates));
     let mut tera = match Tera::new(&template_path) {
         Ok(t) => t,

--- a/src/templates/toc.rs
+++ b/src/templates/toc.rs
@@ -47,7 +47,7 @@ impl Toc {
         let mut prev_headline_level = 0;
         let mut at_headline_root = false;
         let mut headline_root_lvl = 0;
-        let list_type = list_type.unwrap_or("ol".to_string());
+        let list_type = list_type.as_deref().unwrap_or("ol");
         let exclude_root = exclude_root.unwrap_or(false);
         for headline in parsed.headlines() {
             let title = headline.title(&parsed);
@@ -58,8 +58,6 @@ impl Toc {
             let mut write_headline = || {
                 // if the current hl_lvl we are iterating on is less than the depth..
                 if hl_lvl <= user_preferred_depth {
-
-
                     // and it's more than the prev headline...
                     if hl_lvl > prev_headline_level {
                         // let's open a new ul/ol tag for it.
@@ -73,7 +71,6 @@ impl Toc {
                         for _ in 0..gap_between_headlines {
                             write!(writer, "</{0}>", list_type)
                                 .expect("Failed to use writer in toc function.");
-
                         }
                     }
 
@@ -92,7 +89,7 @@ impl Toc {
                         &title.raw, headline_html_str
                     )
                     .expect("Failed to write table of contents");
-                prev_headline_level = hl_lvl;
+                    prev_headline_level = hl_lvl;
                 // ?????
                 } else {
                     prev_headline_level = hl_lvl;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,17 +4,10 @@ use std::path::{Path, PathBuf};
 use tera::Tera;
 
 pub fn load_files(cwd: &Path, pattern: &str) -> Vec<PathBuf> {
-    let mut output: Vec<PathBuf> = Vec::new();
-    let pattern_path = PathBuf::new().join(&cwd).join(pattern);
-    let pattern_path_str = pattern_path.into_os_string().into_string().unwrap();
+    let pattern_path = cwd.join(pattern);
+    let pattern_path_str = pattern_path.to_str().unwrap();
 
-    for entry in glob(&pattern_path_str).unwrap() {
-        match entry {
-            Ok(path) => output.push(path),
-            Err(_e) => (),
-        }
-    }
-    output
+    glob(pattern_path_str).unwrap().flatten().collect()
 }
 
 /// Turns a space delimited string into a slug, with dashes instead.
@@ -27,7 +20,7 @@ pub fn slugify(s: &str) -> String {
 }
 
 pub fn exit() -> ! {
-    ::std::process::exit(1);
+    std::process::exit(1);
 }
 
 /// transform_org_link_to_html converts an org link such as:
@@ -111,7 +104,7 @@ pub fn is_local_org_file(link_path: &str) -> bool {
 }
 
 pub fn is_local_img_file(s: &str) -> bool {
-    org_str_is_img_link(s.clone()) && is_local_file_link(s.clone())
+    org_str_is_img_link(s) && is_local_file_link(s)
 }
 
 // get_template
@@ -122,13 +115,13 @@ pub fn get_template(tera: &Tera, template: &str) -> Result<String, FirnError> {
     let default_template_name = "default.html".to_string();
     if tera
         .get_template_names()
-        .any(|x| x == template_with_html.as_str())
+        .any(|x| x == template_with_html)
     {
         return Ok(template_with_html);
     }
     Ok(default_template_name)
 }
 
-pub fn path_to_string(p: &PathBuf) -> String {
+pub fn path_to_string(p: &Path) -> String {
     p.display().to_string()
 }


### PR DESCRIPTION
Highlights:

- fixes outstanding clippy warnings, like not using `Deref` to accept general `&Path` arguments in functions
- uses deref to defer allocating new `Strings` until necessary
- simplifies some for loops using `IntoIterator`