### PR TITLE
add: tree layout for sitemap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "grass",
  "notify",
  "orgize",
+ "percent-encoding",
  "rayon",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,5 @@ grass = { version = "0.10.8", default-features = false, features = ["random"] }
 tokio = { version = "1.0.1", default-features = false, features = ["rt", "fs", "full"] }
 warp = "0.3"
 notify = "4"
+percent-encoding = "2.1.0"
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::{
     errors::{FirnError, FirnErrorType},
     org::{self, OrgMetadata},
+    sitemap::SitemapTree,
     templates::{self},
     templates::{
         data,
@@ -12,6 +13,7 @@ use crate::{
 
 use anyhow::{Context, Result};
 use glob::glob;
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use rayon::prelude::*;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -19,6 +21,17 @@ use std::process::Command;
 use std::{collections::HashMap, fs::create_dir_all};
 use tera;
 
+const PATH_PERCENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'#')
+    .add(b'\'')
+    .add(b'?')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}');
 // TODO: move this to another file
 #[derive(Debug, Clone)]
 pub struct BaseUrl {
@@ -71,7 +84,7 @@ impl BaseUrl {
                 Component::Normal(f) => {
                     link_tail.push(f);
                 }
-                _ => ()
+                _ => (),
             }
         }
         link_res.push(parent_dirs);
@@ -104,6 +117,7 @@ pub struct Config<'a> {
     // Data specifically for templates / user interaction:
     pub user_config: UserConfig,
     pub sitemap: Vec<LinkData>,
+    pub sitemap_tree: SitemapTree,
     pub sitemap_mru: Vec<LinkData>,
     pub sitemap_mrp: Vec<LinkData>,
     pub tag_page: PathBuf,
@@ -163,6 +177,7 @@ impl<'a> Config<'a> {
             tags_map: HashMap::new(),
             serve_port: 8080,
             sitemap: Vec::new(),
+            sitemap_tree: SitemapTree::new(),
             sitemap_mru: Vec::new(),
             sitemap_mrp: Vec::new(),
             paths_org_files: Vec::new(),
@@ -366,10 +381,12 @@ impl<'a> Config<'a> {
         let mut out: Vec<LinkData> = Vec::new();
         for v in self.global_sitemap.values() {
             if let org::OrgMetadataType::Sitemap(_fm) = &v.entity {
+                let web_path = util::path_to_string(&v.originating_file_web_path);
+                // https://url.spec.whatwg.org/#path-percent-encode-set
                 let sitemap_item_url = format!(
                     "{}/{}",
                     self.user_config.site.url,
-                    util::path_to_string(&v.originating_file_web_path)
+                    utf8_percent_encode(&web_path, PATH_PERCENT_ENCODE_SET)
                 );
                 let x = LinkData::new(
                     sitemap_item_url,
@@ -382,6 +399,33 @@ impl<'a> Config<'a> {
         }
         out.sort_by_key(|ld| ld.file.clone());
         self.sitemap = out;
+
+        let mut values: Vec<&OrgMetadata> = self
+            .global_sitemap
+            .values()
+            .filter_map(|v| match &v.entity {
+                org::OrgMetadataType::Sitemap(_fm) => Some(v),
+                _ => None,
+            })
+            .collect();
+        values.sort_by_key(|v| v.originating_file_web_path.clone());
+        for v in values {
+            let web_path = util::path_to_string(&v.originating_file_web_path);
+            // https://url.spec.whatwg.org/#path-percent-encode-set
+            let sitemap_item_url = format!(
+                "{}/{}",
+                self.user_config.site.url,
+                utf8_percent_encode(&web_path, PATH_PERCENT_ENCODE_SET)
+            );
+            let x = LinkData::new(
+                sitemap_item_url,
+                v.originating_file.clone(),
+                LinkMeta::Sitemap,
+                Some(v.front_matter.clone()),
+            );
+            self.sitemap_tree
+                .insert(v.originating_file_web_path.clone(), x);
+        }
     }
 
     /// render - iterates over all org files and call their render function.
@@ -430,6 +474,7 @@ impl<'a> Config<'a> {
             ctx.insert("title", &tag_name);
             ctx.insert("tags", &self.tags_list);
             ctx.insert("sitemap", &self.sitemap);
+            ctx.insert("nodes", &self.sitemap_tree.nodes);
             ctx.insert("config", &self.user_config);
 
             let tag_file_name = format!("{}.html", tag_name);

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,6 @@ use crate::{
 
 use anyhow::{Context, Result};
 use glob::glob;
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use rayon::prelude::*;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -21,17 +20,6 @@ use std::process::Command;
 use std::{collections::HashMap, fs::create_dir_all};
 use tera;
 
-const PATH_PERCENT_ENCODE_SET: &AsciiSet = &CONTROLS
-    .add(b' ')
-    .add(b'"')
-    .add(b'<')
-    .add(b'>')
-    .add(b'#')
-    .add(b'\'')
-    .add(b'?')
-    .add(b'`')
-    .add(b'{')
-    .add(b'}');
 // TODO: move this to another file
 #[derive(Debug, Clone)]
 pub struct BaseUrl {
@@ -386,7 +374,7 @@ impl<'a> Config<'a> {
                 let sitemap_item_url = format!(
                     "{}/{}",
                     self.user_config.site.url,
-                    utf8_percent_encode(&web_path, PATH_PERCENT_ENCODE_SET)
+                    util::percent_encode(&web_path)
                 );
                 let x = LinkData::new(
                     sitemap_item_url,
@@ -415,7 +403,7 @@ impl<'a> Config<'a> {
             let sitemap_item_url = format!(
                 "{}/{}",
                 self.user_config.site.url,
-                utf8_percent_encode(&web_path, PATH_PERCENT_ENCODE_SET)
+                util::percent_encode(&web_path)
             );
             let x = LinkData::new(
                 sitemap_item_url,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod serve;
 pub mod templates;
 pub mod user_config;
 pub mod util;
+pub mod sitemap;
 
 use std::env;
 use std::path::PathBuf;

--- a/src/org.rs
+++ b/src/org.rs
@@ -9,7 +9,7 @@ use orgize::{elements, Element, Event, Org};
 use serde::Serialize;
 use slugify::slugify;
 use std::fs;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use tera::Context;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Clone)]
@@ -53,7 +53,8 @@ impl<'a> OrgMetadata<'a> {
         let file_title = front_matter.title.clone();
         let originating_file_web_path = web_path.to_path_buf();
         let originating_file_path = file_path.to_path_buf();
-        let originating_file = file_title.unwrap_or_else(|| util::path_to_string(&originating_file_path));
+        let originating_file =
+            file_title.unwrap_or_else(|| util::path_to_string(&originating_file_path));
         // TODO: write a function that cleans headlines - removes links, etc etc
         // etc - from raw. Headline stuff - not every metadata has an associated
         // headline necessarily (ie, links in an org doc before a headline
@@ -256,22 +257,14 @@ impl<'a> OrgFile<'a> {
     pub fn valid_for_rendering(&self) -> Result<bool, FirnError> {
         if self.front_matter.title.is_none() {
             return Err(FirnError::new(
-                &format!(
-                    "{} {}",
-                    "No title found for: ",
-                    self.file_path.display()
-                ),
+                &format!("{} {}", "No title found for: ", self.file_path.display()),
                 FirnErrorType::FrontMatterNoTitle,
             ));
         }
 
         if self.front_matter.is_private() {
             return Err(FirnError::new(
-                &format!(
-                    "{} {}",
-                    "Private file: ",
-                    self.file_path.display()
-                ),
+                &format!("{} {}", "Private file: ", self.file_path.display()),
                 FirnErrorType::IsPrivateFile,
             ));
         }
@@ -322,7 +315,8 @@ impl<'a> OrgFile<'a> {
             // if any global tags match any of the tags of this file, include 'em.
             if let OrgMetadataType::Tag(global_tag, _) = &g_tag.entity {
                 for local_tag in &self.tags {
-                    if let OrgMetadataType::Tag(local_tag_name, local_tag_type) = &local_tag.entity {
+                    if let OrgMetadataType::Tag(local_tag_name, local_tag_type) = &local_tag.entity
+                    {
                         let related_item_url = format!(
                             "{}/{}",
                             cfg.user_config.site.url,
@@ -331,8 +325,7 @@ impl<'a> OrgFile<'a> {
 
                         if let OrgTagType::FirnTag = local_tag_type {
                             if local_tag_name == global_tag
-                                && local_tag.originating_file_path
-                                    != g_tag.originating_file_path
+                                && local_tag.originating_file_path != g_tag.originating_file_path
                             {
                                 let new_link = templates::links::LinkData::new(
                                     related_item_url,
@@ -360,8 +353,11 @@ impl<'a> OrgFile<'a> {
             // if the weblink matches self's web_path it's a match.
             if let OrgMetadataType::Link(link) = &g_link.entity {
                 let new_link_path = link.path.to_owned().to_string();
-                let web_link =
-                    util::transform_org_link_to_html(cfg.base_url.clone(), new_link_path, self.file_path.clone());
+                let web_link = util::transform_org_link_to_html(
+                    cfg.base_url.clone(),
+                    new_link_path,
+                    self.file_path.clone(),
+                );
 
                 let backlink_item_url = format!(
                     "{}/{}",
@@ -394,8 +390,10 @@ impl<'a> OrgFile<'a> {
         ctx.insert("related", &self.get_related_files(cfg));
         ctx.insert("logbook", &logbook_sum.num_hours());
         ctx.insert("sitemap", &cfg.sitemap);
+        ctx.insert("sitemap_layout", &cfg.user_config.sitemap.layout);
         ctx.insert("config", &cfg.user_config);
         ctx.insert("tags", &cfg.tags_list);
+        ctx.insert("nodes", &cfg.sitemap_tree.nodes);
     }
 
     /// render spits out html to disk.

--- a/src/org.rs
+++ b/src/org.rs
@@ -320,7 +320,9 @@ impl<'a> OrgFile<'a> {
                         let related_item_url = format!(
                             "{}/{}",
                             cfg.user_config.site.url,
-                            util::path_to_string(&g_tag.originating_file_web_path)
+                            util::percent_encode(&util::path_to_string(
+                                &g_tag.originating_file_web_path
+                            ))
                         );
 
                         if let OrgTagType::FirnTag = local_tag_type {
@@ -362,7 +364,7 @@ impl<'a> OrgFile<'a> {
                 let backlink_item_url = format!(
                     "{}/{}",
                     cfg.user_config.site.url,
-                    util::path_to_string(&g_link.originating_file_web_path)
+                    util::percent_encode(&util::path_to_string(&g_link.originating_file_web_path))
                 );
 
                 if web_link == self.full_url {

--- a/src/sitemap.rs
+++ b/src/sitemap.rs
@@ -1,0 +1,118 @@
+/* Sitemap.rs: Tree-like structure for rendering sitemap */
+use crate::templates::links::LinkData;
+use serde::Serialize;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+#[derive(Debug, PartialEq)]
+pub struct SitemapTree {
+    pub dummyroot: usize, // 0 is the dummyroot
+    pub nodes: Vec<SitemapTreeNode>,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct SitemapTreeNode {
+    pub path_comp: String, // the path component that this node represents
+    pub data: Option<LinkData>,
+    pub next_sibling: Option<usize>,
+    pub first_child: Option<usize>,
+    pub last_child: Option<usize>,
+}
+
+impl SitemapTreeNode {
+    pub fn add_child(&mut self, child: usize) {
+        if self.first_child == None {
+            self.first_child = Some(child);
+        }
+        self.last_child = Some(child);
+    }
+
+    pub fn add_next_sibling(&mut self, sibling: usize) {
+        self.next_sibling = Some(sibling);
+    }
+}
+
+impl SitemapTree {
+    pub fn new() -> SitemapTree {
+        let nodes = vec![SitemapTreeNode {
+            path_comp: String::from(""),
+            data: None,
+            next_sibling: None,
+            first_child: None,
+            last_child: None,
+        }];
+        SitemapTree {
+            dummyroot: 0,
+            nodes,
+        }
+    }
+    pub fn append(
+        &mut self,
+        os_path_comp: OsString,
+        data: Option<LinkData>,
+        parent: usize,
+    ) -> usize {
+        // Get the next free index
+        let next_index = self.nodes.len();
+        let child = next_index;
+        let path_comp = os_path_comp.into_string();
+        self.nodes.push(SitemapTreeNode {
+            path_comp: path_comp.unwrap(),
+            data,
+            next_sibling: None,
+            first_child: None,
+            last_child: None,
+        });
+        self.nodes[parent].add_child(next_index);
+        child
+    }
+    pub fn insert(&mut self, p: PathBuf, data: LinkData) {
+        let comps: Vec<_> = p.components().map(|comp| comp.as_os_str()).collect();
+        let mut i = 0;
+        let mut current_node = Some(self.dummyroot);
+        'traverse: loop {
+            if current_node == None || i == comps.len() {
+                break 'traverse;
+            }
+            let mut last_child = None;
+            let mut child = self.nodes[current_node.unwrap()].first_child;
+            'traverse_children: loop {
+                match child {
+                    None => {
+                        let new_node;
+                        if i < comps.len() - 1 {
+                            new_node =
+                                self.append(comps[i].to_os_string(), None, current_node.unwrap());
+                        } else {
+                            // it's a leaf
+                            new_node = self.append(
+                                comps[i].to_os_string(),
+                                Some(data.clone()),
+                                current_node.unwrap(),
+                            );
+                        };
+
+                        if let Some(x) = last_child {
+                            // it's not the first child
+                            let v: &mut SitemapTreeNode = &mut self.nodes[x];
+                            v.add_next_sibling(new_node);
+                        }
+                        child = Some(new_node);
+                        break 'traverse_children;
+                    }
+                    Some(x) => {
+                        let comp = self.nodes[x].path_comp.clone();
+                        if OsString::from(comp) == comps[i] {
+                            break 'traverse_children;
+                        } else {
+                            last_child = child;
+                            child = self.nodes[child.unwrap()].next_sibling;
+                        }
+                    }
+                }
+            }
+            current_node = child;
+            i += 1;
+        }
+    }
+}

--- a/src/templates/links.rs
+++ b/src/templates/links.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 // -- Link data for Tera to loop over --------------------------------------------
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Clone)]
 pub enum LinkMeta {
     Backlink,
     RelatedFile,
@@ -11,7 +11,7 @@ pub enum LinkMeta {
     Sitemap,
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Clone)]
 pub struct LinkData {
     pub path: String,
     pub file: String,

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -27,10 +27,16 @@ pub struct FileConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SitemapConfig {
+    pub layout: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UserConfig {
     pub site: SiteConfig,
     pub file: FileConfig,
     pub tags: TagConfig,
+    pub sitemap: SitemapConfig,
 }
 
 impl UserConfig {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use crate::{config::BaseUrl, errors::FirnError};
 use glob::glob;
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use std::path::{Path, PathBuf};
 use tera::Tera;
 
@@ -23,8 +24,6 @@ pub fn exit() -> ! {
     std::process::exit(1);
 }
 
-
-
 pub fn transform_org_link_to_html(
     base_url: BaseUrl,
     org_link_path: String,
@@ -40,7 +39,7 @@ pub fn transform_org_link_to_html(
         link_path = str::replace(&link_path, ".org", ".html");
         link_path = str::replace(&link_path, "file:", "");
         let x = base_url.build(link_path, file_path);
-        return x
+        return x;
 
     // <2> it's a local image
     } else if is_local_img_file(&link_path) {
@@ -104,6 +103,22 @@ pub fn get_template(tera: &Tera, template: &str) -> Result<String, FirnError> {
 
 pub fn path_to_string(p: &Path) -> String {
     p.display().to_string()
+}
+
+const PATH_PERCENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'#')
+    .add(b'\'')
+    .add(b'?')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}');
+
+pub fn percent_encode(p: &String) -> String {
+    utf8_percent_encode(p, PATH_PERCENT_ENCODE_SET).to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The "tree" layout for sitemap is to render the directories where
the org files reside, which may be useful for some who want their
sitemap more organized. 

To use the layout, simply change `sitemap.layout` in `config.yaml`
to `"tree"`. Any values other than that will fall back to the default layout.

Currently this layout sorts the files by their real path on the machine 
rather than by their titles, so if the titles are not consistent with their
filenames, the sitemap will probably be different in that case.

This pr also uses the percent representation in sitemap urls. It fixes 
the broken link issue if the filenames and dirnames have space, question 
mark, etc.
 